### PR TITLE
Refactor tool registration in multiple sections to streamline code

### DIFF
--- a/src/plex_mcp/sections/advanced_search.py
+++ b/src/plex_mcp/sections/advanced_search.py
@@ -52,46 +52,14 @@ class AdvancedSearchSection:
     def _register_tools(self) -> None:
         """Register all advanced search-related MCP tools."""
         # Register tools using the new FastMCP API
-        self.mcp.tool(
-            self.global_search,
-            name="global_search",
-            description="Search across all library sections for content",
-        )
-        self.mcp.tool(
-            self.advanced_search,
-            name="advanced_search",
-            description="Perform advanced search with filters and sorting",
-        )
-        self.mcp.tool(
-            self.search_by_year,
-            name="search_by_year",
-            description="Search for content by year or year range",
-        )
-        self.mcp.tool(
-            self.search_by_genre,
-            name="search_by_genre",
-            description="Search for content by genre",
-        )
-        self.mcp.tool(
-            self.search_by_rating,
-            name="search_by_rating",
-            description="Search for content by rating",
-        )
-        self.mcp.tool(
-            self.search_by_duration,
-            name="search_by_duration",
-            description="Search for content by duration range",
-        )
-        self.mcp.tool(
-            self.search_by_keyword,
-            name="search_by_keyword",
-            description="Search for content by keyword in title, summary, or tags",
-        )
-        self.mcp.tool(
-            self.get_search_suggestions,
-            name="get_search_suggestions",
-            description="Get search suggestions based on partial input",
-        )
+        self.mcp.tool(self.global_search)
+        self.mcp.tool(self.advanced_search)
+        self.mcp.tool(self.search_by_year)
+        self.mcp.tool(self.search_by_genre)
+        self.mcp.tool(self.search_by_rating)
+        self.mcp.tool(self.search_by_duration)
+        self.mcp.tool(self.search_by_keyword)
+        self.mcp.tool(self.get_search_suggestions)
 
     def global_search(
         self,

--- a/src/plex_mcp/sections/client_control.py
+++ b/src/plex_mcp/sections/client_control.py
@@ -52,41 +52,13 @@ class ClientControlSection:
     def _register_tools(self) -> None:
         """Register all client control-related MCP tools."""
         # Register tools using the new FastMCP API
-        self.mcp.tool(
-            self.list_clients,
-            name="list_clients",
-            description="List all connected Plex clients",
-        )
-        self.mcp.tool(
-            self.get_client_info,
-            name="get_client_info",
-            description="Get detailed information about a specific client",
-        )
-        self.mcp.tool(
-            self.play_media,
-            name="play_media",
-            description="Play media on a specific client",
-        )
-        self.mcp.tool(
-            self.control_playback,
-            name="control_playback",
-            description="Control playback (play, pause, stop, seek) on a client",
-        )
-        self.mcp.tool(
-            self.set_volume,
-            name="set_volume",
-            description="Set volume on a client",
-        )
-        self.mcp.tool(
-            self.navigate_client,
-            name="navigate_client",
-            description="Navigate client interface (up, down, left, right, select, back)",
-        )
-        self.mcp.tool(
-            self.get_playback_state,
-            name="get_playback_state",
-            description="Get current playback state of a client",
-        )
+        self.mcp.tool(self.list_clients)
+        self.mcp.tool(self.get_client_info)
+        self.mcp.tool(self.play_media)
+        self.mcp.tool(self.control_playback)
+        self.mcp.tool(self.set_volume)
+        self.mcp.tool(self.navigate_client)
+        self.mcp.tool(self.get_playback_state)
 
     def list_clients(self) -> dict[str, Any]:
         """

--- a/src/plex_mcp/sections/collections.py
+++ b/src/plex_mcp/sections/collections.py
@@ -52,46 +52,14 @@ class CollectionsSection:
     def _register_tools(self) -> None:
         """Register all collections-related MCP tools."""
         # Register tools using the new FastMCP API
-        self.mcp.tool(
-            self.list_collections,
-            name="list_collections",
-            description="List all collections in a library section",
-        )
-        self.mcp.tool(
-            self.get_collection_info,
-            name="get_collection_info",
-            description="Get detailed information about a specific collection",
-        )
-        self.mcp.tool(
-            self.create_collection,
-            name="create_collection",
-            description="Create a new collection",
-        )
-        self.mcp.tool(
-            self.add_to_collection,
-            name="add_to_collection",
-            description="Add items to a collection",
-        )
-        self.mcp.tool(
-            self.remove_from_collection,
-            name="remove_from_collection",
-            description="Remove items from a collection",
-        )
-        self.mcp.tool(
-            self.update_collection,
-            name="update_collection",
-            description="Update collection metadata (title, summary, etc.)",
-        )
-        self.mcp.tool(
-            self.delete_collection,
-            name="delete_collection",
-            description="Delete a collection",
-        )
-        self.mcp.tool(
-            self.search_collections,
-            name="search_collections",
-            description="Search for collections by title or other criteria",
-        )
+        self.mcp.tool(self.list_collections)
+        self.mcp.tool(self.get_collection_info)
+        self.mcp.tool(self.create_collection)
+        self.mcp.tool(self.add_to_collection)
+        self.mcp.tool(self.remove_from_collection)
+        self.mcp.tool(self.update_collection)
+        self.mcp.tool(self.delete_collection)
+        self.mcp.tool(self.search_collections)
 
     def _get_library_section(self, section_title: str) -> Any:
         """

--- a/src/plex_mcp/sections/movies.py
+++ b/src/plex_mcp/sections/movies.py
@@ -52,41 +52,13 @@ class MoviesSection:
     def _register_tools(self) -> None:
         """Register all movies-related MCP tools."""
         # Register tools using the new FastMCP API
-        self.mcp.tool(
-            self.search_movies,
-            name="search_movies",
-            description="Search for movies in the Plex library",
-        )
-        self.mcp.tool(
-            self.get_movies_library,
-            name="get_movies_library",
-            description="Get information about the movies library section",
-        )
-        self.mcp.tool(
-            self.get_movie_info,
-            name="get_movie_info",
-            description="Get detailed information about a specific movie",
-        )
-        self.mcp.tool(
-            self.search_movies_by_genre,
-            name="search_movies_by_genre",
-            description="Search for movies by genre",
-        )
-        self.mcp.tool(
-            self.search_movies_by_year,
-            name="search_movies_by_year",
-            description="Search for movies by year or year range",
-        )
-        self.mcp.tool(
-            self.get_recently_added_movies,
-            name="get_recently_added_movies",
-            description="Get recently added movies",
-        )
-        self.mcp.tool(
-            self.get_movies_by_rating,
-            name="get_movies_by_rating",
-            description="Get movies filtered by rating",
-        )
+        self.mcp.tool(self.search_movies)
+        self.mcp.tool(self.get_movies_library)
+        self.mcp.tool(self.get_movie_info)
+        self.mcp.tool(self.search_movies_by_genre)
+        self.mcp.tool(self.search_movies_by_year)
+        self.mcp.tool(self.get_recently_added_movies)
+        self.mcp.tool(self.get_movies_by_rating)
 
     def _get_movies_section(self) -> Any:
         """

--- a/src/plex_mcp/sections/music.py
+++ b/src/plex_mcp/sections/music.py
@@ -55,41 +55,13 @@ class MusicSection:
     def _register_tools(self) -> None:
         """Register all music-related MCP tools."""
         # Register tools using the new FastMCP API
-        self.mcp.tool(
-            self.search_music_tracks,
-            name="search_music_tracks",
-            description="Search for music tracks in the Plex library",
-        )
-        self.mcp.tool(
-            self.get_music_library,
-            name="get_music_library",
-            description="Get information about the music library section",
-        )
-        self.mcp.tool(
-            self.create_music_playlist,
-            name="create_music_playlist",
-            description="Create a new music playlist with specified tracks",
-        )
-        self.mcp.tool(
-            self.get_random_tracks_by_decade,
-            name="get_random_tracks_by_decade",
-            description="Get random tracks from a specific decade",
-        )
-        self.mcp.tool(
-            self.search_tracks_by_artist,
-            name="search_tracks_by_artist",
-            description="Search for tracks by a specific artist",
-        )
-        self.mcp.tool(
-            self.get_playlist_info,
-            name="get_playlist_info",
-            description="Get information about an existing playlist",
-        )
-        self.mcp.tool(
-            self.delete_playlist,
-            name="delete_playlist",
-            description="Delete an existing playlist",
-        )
+        self.mcp.tool(self.search_music_tracks)
+        self.mcp.tool(self.get_music_library)
+        self.mcp.tool(self.create_music_playlist)
+        self.mcp.tool(self.get_random_tracks_by_decade)
+        self.mcp.tool(self.search_tracks_by_artist)
+        self.mcp.tool(self.get_playlist_info)
+        self.mcp.tool(self.delete_playlist)
 
     def _get_music_section(self) -> Any:
         """

--- a/src/plex_mcp/sections/photo_library.py
+++ b/src/plex_mcp/sections/photo_library.py
@@ -52,41 +52,13 @@ class PhotoLibrarySection:
     def _register_tools(self) -> None:
         """Register all photo library-related MCP tools."""
         # Register tools using the new FastMCP API
-        self.mcp.tool(
-            self.list_photos,
-            name="list_photos",
-            description="List photos in a photo library section",
-        )
-        self.mcp.tool(
-            self.get_photo_info,
-            name="get_photo_info",
-            description="Get detailed information about a specific photo",
-        )
-        self.mcp.tool(
-            self.search_photos,
-            name="search_photos",
-            description="Search for photos by title, date, or other criteria",
-        )
-        self.mcp.tool(
-            self.get_photo_albums,
-            name="get_photo_albums",
-            description="List photo albums in a library section",
-        )
-        self.mcp.tool(
-            self.get_album_photos,
-            name="get_album_photos",
-            description="Get photos from a specific album",
-        )
-        self.mcp.tool(
-            self.get_recently_added_photos,
-            name="get_recently_added_photos",
-            description="Get recently added photos",
-        )
-        self.mcp.tool(
-            self.get_photo_timeline,
-            name="get_photo_timeline",
-            description="Get photos organized by date/timeline",
-        )
+        self.mcp.tool(self.list_photos)
+        self.mcp.tool(self.get_photo_info)
+        self.mcp.tool(self.search_photos)
+        self.mcp.tool(self.get_photo_albums)
+        self.mcp.tool(self.get_album_photos)
+        self.mcp.tool(self.get_recently_added_photos)
+        self.mcp.tool(self.get_photo_timeline)
 
     def _get_library_section(self, section_title: str) -> Any:
         """

--- a/src/plex_mcp/sections/settings.py
+++ b/src/plex_mcp/sections/settings.py
@@ -52,46 +52,14 @@ class SettingsSection:
     def _register_tools(self) -> None:
         """Register all settings-related MCP tools."""
         # Register tools using the new FastMCP API
-        self.mcp.tool(
-            self.get_server_settings,
-            name="get_server_settings",
-            description="Get all server settings",
-        )
-        self.mcp.tool(
-            self.get_setting,
-            name="get_setting",
-            description="Get a specific server setting value",
-        )
-        self.mcp.tool(
-            self.set_setting,
-            name="set_setting",
-            description="Set a server setting value",
-        )
-        self.mcp.tool(
-            self.get_library_sections,
-            name="get_library_sections",
-            description="Get all library sections and their settings",
-        )
-        self.mcp.tool(
-            self.scan_library,
-            name="scan_library",
-            description="Scan a library section for new media",
-        )
-        self.mcp.tool(
-            self.empty_trash,
-            name="empty_trash",
-            description="Empty trash for a library section",
-        )
-        self.mcp.tool(
-            self.analyze_library,
-            name="analyze_library",
-            description="Analyze library section for metadata",
-        )
-        self.mcp.tool(
-            self.get_server_info,
-            name="get_server_info",
-            description="Get detailed server information",
-        )
+        self.mcp.tool(self.get_server_settings)
+        self.mcp.tool(self.get_setting)
+        self.mcp.tool(self.set_setting)
+        self.mcp.tool(self.get_library_sections)
+        self.mcp.tool(self.scan_library)
+        self.mcp.tool(self.empty_trash)
+        self.mcp.tool(self.analyze_library)
+        self.mcp.tool(self.get_server_info)
 
     def get_server_settings(self) -> dict[str, Any]:
         """

--- a/src/plex_mcp/sections/tv_shows.py
+++ b/src/plex_mcp/sections/tv_shows.py
@@ -52,36 +52,12 @@ class TVShowsSection:
     def _register_tools(self) -> None:
         """Register all TV shows-related MCP tools."""
         # Register tools using the new FastMCP API
-        self.mcp.tool(
-            self.search_tv_shows,
-            name="search_tv_shows",
-            description="Search for TV shows in the Plex library",
-        )
-        self.mcp.tool(
-            self.get_tv_shows_library,
-            name="get_tv_shows_library",
-            description="Get information about the TV shows library section",
-        )
-        self.mcp.tool(
-            self.get_show_episodes,
-            name="get_show_episodes",
-            description="Get episodes for a specific TV show",
-        )
-        self.mcp.tool(
-            self.get_episode_info,
-            name="get_episode_info",
-            description="Get detailed information about a specific episode",
-        )
-        self.mcp.tool(
-            self.search_episodes_by_show,
-            name="search_episodes_by_show",
-            description="Search for episodes within a specific TV show",
-        )
-        self.mcp.tool(
-            self.get_recently_added_shows,
-            name="get_recently_added_shows",
-            description="Get recently added TV shows",
-        )
+        self.mcp.tool(self.search_tv_shows)
+        self.mcp.tool(self.get_tv_shows_library)
+        self.mcp.tool(self.get_show_episodes)
+        self.mcp.tool(self.get_episode_info)
+        self.mcp.tool(self.search_episodes_by_show)
+        self.mcp.tool(self.get_recently_added_shows)
 
     def _get_tv_shows_section(self) -> Any:
         """

--- a/src/plex_mcp/sections/user_management.py
+++ b/src/plex_mcp/sections/user_management.py
@@ -52,46 +52,14 @@ class UserManagementSection:
     def _register_tools(self) -> None:
         """Register all user management-related MCP tools."""
         # Register tools using the new FastMCP API
-        self.mcp.tool(
-            self.get_users,
-            name="get_users",
-            description="Get list of all users with access to the server",
-        )
-        self.mcp.tool(
-            self.get_user_info,
-            name="get_user_info",
-            description="Get detailed information about a specific user",
-        )
-        self.mcp.tool(
-            self.get_user_permissions,
-            name="get_user_permissions",
-            description="Get permissions for a specific user",
-        )
-        self.mcp.tool(
-            self.get_user_activity,
-            name="get_user_activity",
-            description="Get recent activity for a specific user",
-        )
-        self.mcp.tool(
-            self.get_user_watch_history,
-            name="get_user_watch_history",
-            description="Get watch history for a specific user",
-        )
-        self.mcp.tool(
-            self.get_user_recommendations,
-            name="get_user_recommendations",
-            description="Get content recommendations for a specific user",
-        )
-        self.mcp.tool(
-            self.get_user_libraries,
-            name="get_user_libraries",
-            description="Get accessible libraries for a specific user",
-        )
-        self.mcp.tool(
-            self.get_user_settings,
-            name="get_user_settings",
-            description="Get user-specific settings and preferences",
-        )
+        self.mcp.tool(self.get_users)
+        self.mcp.tool(self.get_user_info)
+        self.mcp.tool(self.get_user_permissions)
+        self.mcp.tool(self.get_user_activity)
+        self.mcp.tool(self.get_user_watch_history)
+        self.mcp.tool(self.get_user_recommendations)
+        self.mcp.tool(self.get_user_libraries)
+        self.mcp.tool(self.get_user_settings)
 
     def get_users(self) -> dict[str, Any]:
         """


### PR DESCRIPTION
- Simplified the registration of tools in the AdvancedSearchSection, ClientControlSection, CollectionsSection, MoviesSection, MusicSection, PhotoLibrarySection, SettingsSection, TVShowsSection, and UserManagementSection by removing redundant parameters in the `self.mcp.tool()` calls.
- This change enhances code readability and maintainability while preserving existing functionality.